### PR TITLE
fix unprotected control characters

### DIFF
--- a/_episodes/06-manipulating-MARC-data.md
+++ b/_episodes/06-manipulating-MARC-data.md
@@ -25,9 +25,11 @@ keypoints:
 We've seen how we can manually and individually edit records in the MarcEditor, however, MarcEdit provides a number of more powerful ways to manipulate our MARC data. Fields, subfields, indicators can be added, removed, or changed. Fixed fields can be corrected. Fields and subfields specific to RDA can be added while AACR2 conventions are removed. It is possible to work with a subset of MARC data and then incorporate those changes into the original whole MARC data set. The variations sometime seem endless and give more weight to the nickname of MarcEdit, the swiss army knife of MARC data.
 
 ### Add/Delete a MARC field
+
 To add or delete a MARC field, go to Tools in the upper menu in the MarcEditor and select Add/Delete Field. This will open a new Batch Editing Tools window. The Add/Delete Field functions are on the same menu level and you will need to select the action of either add or delete using the buttons on the right hand side.
 
 In the top middle section of the window, there are two data entry fields: Field and Field Data. Enter the MARC field number you want to add or delete in the Field dialogue box. Then enter the indicators, subfields, and data in Field Data dialogue box. Remember to include the dollar sign to indicate a subfield.
+
   ![MarcEdit empty Add/Delete Field dialog](../fig/addDeleteField.png)
   ![MarcEdit completed Add/Delete Field dialog](../fig/example_addDelete.png)
 
@@ -35,9 +37,9 @@ To add the field, click the Add Field button and to delete any matching fields, 
 
 For both the Add Field and Delete Field functions there are a number of different options that can be applied to control the updates.
 
-The options to Add a Field include, if the field you are adding already exists, it can be inserted first in the list of those MARC fields or last. MARC fields can be added only if that MARC field is not already present in that record or based on the presence of other criteria found in other MARC fields. For example, a MARC field 655  \4$aElectronic books can be added to only those records that are eBooks based on the data in the LDR or 008.
+The options to Add a Field include, if the field you are adding already exists, it can be inserted first in the list of those MARC fields or last. MARC fields can be added only if that MARC field is not already present in that record or based on the presence of other criteria found in other MARC fields. For example, a MARC field `655  \4$aElectronic books` can be added to only those records that are eBooks based on the data in the LDR or 008.
 
-The options to Delete a Field include removing duplicates, removing MARC fields based on field position, removing MARC fields that do not match what is entered in the Field Data, or removing invalid UTF-8 MARC fields. For example, to ensure that only the field 655  \4$aElectronic books. is present in the MARC data, the option Remove if field data does not match can be selected.
+The options to Delete a Field include removing duplicates, removing MARC fields based on field position, removing MARC fields that do not match what is entered in the Field Data, or removing invalid UTF-8 MARC fields. For example, to ensure that only the field `655  \4$aElectronic books`. is present in the MARC data, the option Remove if field data does not match can be selected.
 
 >## Add and then delete a MARC field
 >
@@ -47,12 +49,12 @@ The options to Delete a Field include removing duplicates, removing MARC fields 
 > > ## Solution
 > > 1. Go to Tools in the upper menu in the MarcEditor
 > > 2. Select Add/Delete Field (F7)
-> > 3. In the Field box enter 655, in the Field Data box enter \4$aElectronic books.
+> > 3. In the Field box enter 655, in the Field Data box enter `\4$aElectronic books`.
 > > 4. Click Add Field. You can also preview this change by clicking on the arrow on the right of Add Field and selecting Preview in the 7.5 version of MarcEdit
 > > 5. Check your MARC data. Was this MARC field added?
 > > 6. To delete this field, go back to Tools and select Add/Delete Field (F7)
 > > 7. In the Field box enter 655
-> > 8. In the Field Data box enter \4$aElectronic books.
+> > 8. In the Field Data box enter `\4$aElectronic books`.
 > > 9. Click on the Delete Field button. You can also preview this change by clicking on the arrow on the right side and selecting Preview in the 7.5 version of MarcEdit
 > {: .solution}
 {: .challenge}
@@ -98,8 +100,8 @@ To replace text in a subfield, enter the MARC field, the subfield, the text (or 
 
 >## Add and then Delete a MARC subfield
 >
->1. Change the $5 for the MARC field 500 from FU to your own Library of Congress Organization Code. If you are unsure of your Library of Congress Organization Code, update the code to XYZ.
->2. Delete that $5 that you just changed.
+>1. Change the `$5` for the MARC field 500 from FU to your own Library of Congress Organization Code. If you are unsure of your Library of Congress Organization Code, update the code to XYZ.
+>2. Delete that `$5` that you just changed.
 >
 > > ## Solution
 > > 1. Go to Tools in the upper menu in the MarcEditor
@@ -127,13 +129,13 @@ To replace text in a subfield, enter the MARC field, the subfield, the text (or 
 >3. Click Process
 {: .checklist}
 
->## Use the Build New Field to add a proxy to the 856$u
+>## Use the Build New Field to add a proxy to the `856$u`
 >
->1. For eResources, it is sometimes necessary to add your institution's proxy information to the url in the 856$u. Add https:\\exampleproxy.edu/login?url= prefix to the url in the 856$u.
+>1. For eResources, it is sometimes necessary to add your institution's proxy information to the url in the `856$u`. Add `https://exampleproxy.edu/login?url=` prefix to the url in the `856$u`.
 >
 > > ## Solution
 > > 1. Go to Tools → Build New Field
-> > 2. In the new window, in the field box, type in =856  40\$uhttps:\\exampleproxy.edu/login?url={856$u}
+> > 2. In the new window, in the field box, type in `=856  40\$uhttps://exampleproxy.edu/login?url={856$u}`
 > > 3. Select the box to "Replace Existing Field"
 > > 4. Click Process
 > {: .solution}
@@ -152,16 +154,16 @@ Sometimes it is necessary to change one or both indicators of a MARC field. To e
 > > ## Solution
 > > 1. Go to Tools in the upper menu in the MarcEditor
 > > 2. Select Edit Indicators (F8)
-> > 3. Add 050 in the Field box, \4 in the Indicators box, and 14 in the Replace With Indicators box. Leave the Field data box blank
+> > 3. Add `050` in the Field box, `\4` in the Indicators box, and `14` in the Replace With Indicators box. Leave the Field data box blank
 > > 4. Click on the Replace button.
-> > 5. Check your MARC data. Were the 050 \4 updated to be 050  14?
+> > 5. Check your MARC data. Were the `050 \4` updated to be `050  14`?
 > {: .solution}
 {: .challenge}
 
 ## RDA Helper
 Records aren't created equal in that we encounter MARC data that follows different descriptive cataloging standards. There are a number of records cataloged according to the AACR2 standard or even AACR or earlier. Sometimes it is necessary to make sure these records follow the current RDA descriptive cataloging standard. MarcEdit lets you do this through the function called RDA Helper.
 
-To run the RDA Helper, go to Tools and select RDA Helper. In the window that opens, you can pick and choose how you would like to transform your records to align better with the RDA descriptive standard. For example, you can add the RDA fields 336, 337, and 338 for content, media, and carrier types. You can update the MARC field 040 to include the $e rda and delete the GMD statement. You can also evaluate the 260/264.
+To run the RDA Helper, go to Tools and select RDA Helper. In the window that opens, you can pick and choose how you would like to transform your records to align better with the RDA descriptive standard. For example, you can add the RDA fields 336, 337, and 338 for content, media, and carrier types. You can update the MARC field 040 to include the `$e` rda and delete the GMD statement. You can also evaluate the 260/264.
 
 ![MarcEdit RDA Helper](../fig/rdaHelper.png)
 
@@ -194,7 +196,7 @@ You can also batch insert an 006 or 008 into your records. To insert a fixed fie
 ## Select Records to Edit
 There are times when you need to work on a subset of your MARC data. The Select Records for Edit function allows you do this.
 
-Go to File and click on Select Records for Edit. In the window, you will see Display Field in the lower right hand corner. This is where you enter the MARC field you want to see displayed once you import your file. You can enter a MARC field and subfield or just a MARC field. The MARC field and/or subfield that you add in this box will provide the criteria you need to select records you want to edit. Once you have entered the Display Field, click on Import File. This will import the MARC (.mrk) file that you are currently working on. You can select another MARC (.mrk) file in the box Source MARC file.
+Go to File and click on Select Records for Edit. In the window, you will see Display Field in the lower right hand corner. This is where you enter the MARC field you want to see displayed once you import your file. You can enter a MARC field and subfield or just a MARC field. The MARC field and/or subfield that you add in this box will provide the criteria you need to select records you want to edit. Once you have entered the Display Field, click on Import File. This will import the MARC (`.mrk`) file that you are currently working on. You can select another MARC (`.mrk`) file in the box Source MARC file.
 
 To select only the records you want to edit, enter your criteria in the Search box and click the magnifying glass icon. Records in your file where the contents of the selected Display Field match your search criteria will be selected. Click on Export Selected to export these records and edit them. When saving the exported records you can choose to save the file as a new record subset (Save As), or merge the edits back into your complete record set (Save).
 
@@ -203,20 +205,20 @@ To select only the records you want to edit, enter your criteria in the Search b
 
 >## Let's add cutters to call numbers in the 099
 >1. Go to File → Select Records to Edit
->2. In the new window, type in 099$b in the Field Display
+>2. In the new window, type in `099$b` in the Field Display
 >3. Click on Import File
->3. In the search box, type in "Display field not found" to locate all records missing 099$b
+>3. In the search box, type in "Display field not found" to locate all records missing `099$b`
 >4. Click the magnifying glass icon. A pop up window will indicate the number of records selected that match your criteria. Click OK.
 >5. Click on Export Selected. A pop up window indicate that your selected records have been extracted. Click OK.
 >6. A new MarcEditor window will open. Note the temporary file name at the top of the editor window indicating this file is distinct from your main file. In the new MarcEditor, go to Tools → Call Number tools → Cuttering Tools → Generate Cutters.
 > 7. In the field box enter 099 and click Process
-> 8. Check your results by using Find All =099
+> 8. Check your results by using Find All `=099`
 > 9. Select File → Save. A pop up window will indicate your extracted data with edits has been saved back into your main file. Click OK.
 {: .checklist}
 
 ## Save and Compile
-The MARC data that you manipulate in the MarcEditor is a human and computer readable mnemonic view that was broken from the binary .mrc file. You will notice that the extension of your file that you are manipulating in the MarcEditor has the file extension of .mrk. If you look at the file in your file directory, sometimes the color is also blue whereas the .mrc or binary MARC file is purple.
+The MARC data that you manipulate in the MarcEditor is a human and computer readable mnemonic view that was broken from the binary .mrc file. You will notice that the extension of your file that you are manipulating in the MarcEditor has the file extension of `.mrk`. If you look at the file in your file directory, sometimes the color is also blue whereas the .mrc or binary MARC file is purple.
 
-When you save or save as in the MarcEditor, you are saving your latest changes as a .mrk (in the friendly view that was broken from the binary .mrc file).
+When you save or save as in the MarcEditor, you are saving your latest changes as a .mrk (in the friendly view that was broken from the binary `.mrc` file).
 
 When you compile, you are saving all of your latest changes and reforming that your record set into its binary .mrc format that can be used to load the records in external systems such as your ILS or LSP.

--- a/_episodes/07-tasks-and-automation.md
+++ b/_episodes/07-tasks-and-automation.md
@@ -90,7 +90,7 @@ If you have created many Tasks, it does help to assign them to groups to more ea
 ## Managing your Tasks
 To edit an existing task, go to Tools → Manage Tasks. In the Task Manger select the task you want to edit, this will highlight the task. Under Task Actions choose Edit Task and click Select. This will open the Edit Task List window. Just like when creating a new task, you can add, delete, or edit functions in your task. Use the up and down arrows to the right to reorder your functions.
 
->## Add a proxy to the 856 40$u in your Task
+>## Add a proxy to the `856 40$u` in your Task
 >
 >1. After you run your Task, your MARC records should have your institution's proxy before the URL. Remember to check your data first to see if there are any proxy stems present. You will need to remove any existing proxies before running your Task. If the MARC data has different types of electronic URLs (resource, related resource, etc.) as noted in the MARC field 856 indicators, you will need to account for that in your Task.
 >
@@ -100,7 +100,7 @@ To edit an existing task, go to Tools → Manage Tasks. In the Task Manger selec
 > > 3. Select the Task you just created. The selected Task will be highlighted.
 > > 4. In Task Actions, select Edit Task and click Select.
 > > 5. Select the plus button and select "Add a Replace All Task"
-> > 6. Replace the 856  40$u with 856  40$u[your proxy]. Remember to add 2 spaces after the MARC field.
+> > 6. Replace the `856  40$u` with `856  40$u[your proxy]`. Remember to add 2 spaces after the MARC field.
 > > 7. Save
 > > 8. Close out of the Task Manager
 > > 9. Run your Task again


### PR DESCRIPTION
This fixes some unprotected control characters that prevented parsing of some episodes for https://github.com/carpentries/lesson-transition/issues/64

I've also switched the `https:\\exampleproxy` example URL to `https://exampleproxy` so that it is a correct URL structure. It will not evaulate because I wrapped it in backticks. 

