### PR TITLE
linked to prerequisite resources

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ site: sandpaper::sandpaper_site
 
 ## Prerequisites
 
-This lesson requires a basic knowledge of the MARC21 standard.
+This lesson requires a [basic knowledge](https://www.loc.gov/marc/96principl.html) of the [MARC21 standard](https://www.loc.gov/marc/).
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
The lesson prerequisite section suggests having basic knowledge of MARC21 without references. Added the links for basic outline as well as the URL to the MARC21 standards homepage. It might be helpful for beginners in acquiring the prerequisites.
