### PR TITLE
Add preliminary glossary content to reference.md

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -1,13 +1,33 @@
 ---
-title: 'FIXME'
+title: 'Glossary'
 ---
 
 ## Glossary
 
-## Glossary
+{:auto\_ids}
+[Dublic Core]{#dc}
+:   A common metadata standard used for describing a wide range of resources across domains. It includes 15 essential elements like title, creator, subject, and date.
 
-FIXME
+[FAST \(Faceted Application of Subject Terminology\)]{#fast}
+:   A simplified subject heading system derived from the Library of Congress Subject Headings (LCSH), designed for faster and more consistent application.
 
+[LSP \(Library Services Platform\)]{#lsp}
+:   A cloud-based, integrated system that unifies library management functions such as cataloging, circulation, acquisitions, and user services, enabling more efficient and flexible library operations. Examples include Ex Libris's Alma, OCLC's WorldShare, and open source solutions like Folio.
 
+[MARC \(Machine-Readable Cataloging\)]{#marc}
+:   A standard format for the representation and exchange of bibliographic and related information in a machine-readable form. Commonly used in libraries for cataloging materials.
 
+[MARC 21]{#marc-21}
+:   A specific MARC format developed and maintained by the Library of Congress, designed to support bibliographic data exchange between library systems.
 
+[OAI \(Open Archives Initiative\)]{#oai}
+:   A framework for facilitating metadata harvesting using the OAI-PMH (Protocol for Metadata Harvesting) standard, enabling interoperability between digital repositories.
+
+[RDA \(Resource Description and Access\)]{#rda}
+:   A descriptive cataloging standard that provides guidelines and instructions on formulating bibliographic data for libraries and cultural heritage organizations.
+
+[Regex \(Regular Expressions\)]{#regex}
+:   A sequence of characters that defines a search pattern, commonly used for string matching and manipulation in text processing.
+
+[UNIMARC]{#unimarc}
+:   A specific MARC format developed by the International Federation of Library Associations (IFLA) to provide a universal framework for library metadata.

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -4,7 +4,6 @@ title: 'Glossary'
 
 ## Glossary
 
-{:auto\_ids}
 [Dublic Core]{#dc}
 :   A common metadata standard used for describing a wide range of resources across domains. It includes 15 essential elements like title, creator, subject, and date.
 


### PR DESCRIPTION
Adds initial set of glossary terms. Does not add links out to glossary terms in-lesson.